### PR TITLE
Implemented APACHE_ALLOW_OVERRIDE_ENABLED env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Supported tags and respective `Dockerfile` links:
 | `APACHE_HOSTNAME_LOOKUPS`            | `Off`                                            |             |
 | `APACHE_HTTP2`                       |                                                  |             |
 | `APACHE_INCLUDE_CONF`                | `conf/conf.d/*.conf`                             |             |
+| `APACHE_ALLOW_OVERRIDE_ENABLED`      | `All`                                            |             |
 | `APACHE_INDEXES_ENABLED`             |                                                  |             |
 | `APACHE_KEEP_ALIVE_TIMEOUT`          | `5`                                              |             |
 | `APACHE_KEEP_ALIVE`                  | `On`                                             |             |

--- a/templates/presets/html.conf.tmpl
+++ b/templates/presets/html.conf.tmpl
@@ -2,6 +2,6 @@ DirectoryIndex {{ getenv "APACHE_DIRECTORY_INDEX" "index.html" }}
 
 <Directory "{{ getenv "APACHE_DOCUMENT_ROOT" "/var/www/html" }}">
     Options FollowSymLinks {{ if (getenv "APACHE_INDEXES_ENABLED") }}Indexes{{ end }}
-    AllowOverride None
+    AllowOverride {{ getenv "APACHE_ALLOW_OVERRIDE_ENABLED" "All" }}
     Require all granted
 </Directory>

--- a/templates/presets/php.conf.tmpl
+++ b/templates/presets/php.conf.tmpl
@@ -2,7 +2,7 @@ DirectoryIndex {{ getenv "APACHE_DIRECTORY_INDEX" "index.php" }}
 
 <Directory "{{ getenv "APACHE_DOCUMENT_ROOT" "/var/www/html" }}">
     Options FollowSymLinks {{ if (getenv "APACHE_INDEXES_ENABLED") }}Indexes{{ end }}
-    AllowOverride All
+    AllowOverride {{ getenv "APACHE_ALLOW_OVERRIDE_ENABLED" "All" }}
     Require all granted
 </Directory>
 


### PR DESCRIPTION
Fixes #9 

It does not make sense that the preset forces the `AllowOverride` directive. `.htaccess` files could also be used to rewrite URLs to an `index.html` file, for example.

I have implemented an environment variable called `APACHE_ALLOW_OVERRIDE_ENABLED` that controls the `AllowOverride` directive and which defaults to `All`.